### PR TITLE
Conditional name char ref decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ A lenient alternative to [hecrj/elm-html-parser](https://package.elm-lang.org/pa
 ```elm
 import Html.Parser 
 
-Html.Parser.run "<p class=greeting>hello <strong>world</strong></p>"
+"<p class=greeting>hello <strong>world</strong></p>"
+|> Html.Parser.run Html.Parser.allCharRefs
 -- Ok 
 --     [ Element "p" [ ("class", "greeting") ] 
 --          [ Text "hello "

--- a/src/Html/CharRefs.elm
+++ b/src/Html/CharRefs.elm
@@ -1,15 +1,10 @@
-module Html.CharRefs exposing (decode)
+module Html.CharRefs exposing (default)
 
 import Dict exposing (Dict)
 
 
-decode : String -> Maybe String
-decode name =
-    Dict.get name dict
-
-
-dict : Dict String String
-dict =
+default : Dict String String
+default =
     -- Source: https://www.w3.org/TR/html5/syntax.html#named-character-references
     [ ( "Aacute", "Á" )
     , ( "aacute", "á" )

--- a/src/Html/CharRefs.elm
+++ b/src/Html/CharRefs.elm
@@ -1,11 +1,15 @@
-module Html.CharRefs exposing (default)
+module Html.CharRefs exposing (all)
 
 import Dict exposing (Dict)
 
 
-default : Dict String String
-default =
-    -- Source: https://www.w3.org/TR/html5/syntax.html#named-character-references
+{-| The exhaustive spec-complete lookup table.
+
+Source: <https://www.w3.org/TR/html5/syntax.html#named-character-references>
+
+-}
+all : Dict String String
+all =
     [ ( "Aacute", "Á" )
     , ( "aacute", "á" )
     , ( "Abreve", "Ă" )

--- a/tests/LocTests.elm
+++ b/tests/LocTests.elm
@@ -2,10 +2,15 @@ module LocTests exposing (..)
 
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer, int, list, string)
+import Html.CharRefs
 import Html.Loc as Q exposing (Loc)
 import Html.Parser exposing (Document, Node(..))
 import Parser exposing (DeadEnd)
 import Test exposing (..)
+
+
+config =
+    Html.Parser.configWithCharRefs
 
 
 type alias DirCase =
@@ -55,7 +60,7 @@ testTraversals cases =
                                     )
 
                         actual =
-                            Html.Parser.run x.html
+                            Html.Parser.run config x.html
                                 |> Result.toMaybe
                                 |> Maybe.andThen List.head
                                 |> Maybe.map Q.toLoc

--- a/tests/LocTests.elm
+++ b/tests/LocTests.elm
@@ -10,7 +10,7 @@ import Test exposing (..)
 
 
 config =
-    Html.Parser.configWithCharRefs
+    Html.Parser.allCharRefs
 
 
 type alias DirCase =

--- a/tests/ParserTests.elm
+++ b/tests/ParserTests.elm
@@ -2,9 +2,14 @@ module ParserTests exposing (..)
 
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer, int, list, string)
+import Html.CharRefs
 import Html.Parser exposing (Document, Node(..))
 import Parser exposing (DeadEnd)
 import Test exposing (..)
+
+
+config =
+    Html.Parser.configWithCharRefs
 
 
 testDoc : List ( String, String, Result (List DeadEnd) Document ) -> List Test
@@ -15,7 +20,7 @@ testDoc cases =
                 (\_ ->
                     let
                         actual =
-                            Html.Parser.runDocument html
+                            Html.Parser.runDocument config html
                     in
                     case expected of
                         Ok _ ->
@@ -41,7 +46,7 @@ testStringRoundtrip cases =
                 (\_ ->
                     let
                         actual =
-                            Html.Parser.run html
+                            Html.Parser.run config html
                                 |> Result.map Html.Parser.nodesToString
                     in
                     case expected of
@@ -68,7 +73,7 @@ testAll cases =
                 (\_ ->
                     let
                         actual =
-                            Html.Parser.run html
+                            Html.Parser.run config html
                     in
                     case expected of
                         Err _ ->
@@ -395,13 +400,13 @@ scriptTests =
 testParseAll : String -> List Node -> (() -> Expectation)
 testParseAll s astList =
     \_ ->
-        Expect.equal (Ok astList) (Html.Parser.run s)
+        Expect.equal (Ok astList) (Html.Parser.run config s)
 
 
 testParse : String -> Node -> (() -> Expectation)
 testParse input expected =
     \_ ->
-        case Html.Parser.run input of
+        case Html.Parser.run config input of
             Err message ->
                 Expect.fail (Parser.deadEndsToString message)
 

--- a/tests/ParserTests.elm
+++ b/tests/ParserTests.elm
@@ -9,7 +9,7 @@ import Test exposing (..)
 
 
 config =
-    Html.Parser.configWithCharRefs
+    Html.Parser.allCharRefs
 
 
 testDoc : List ( String, String, Result (List DeadEnd) Document ) -> List Test


### PR DESCRIPTION
(I hacked this together for some feedback)

Still deciding on the API, but here is the general idea.

Named character reference decoding uses a massive dictionary to look up and decode an entity like `&Delta;` into "Δ".

Here's how it impacts bundle sizes.

When `Html.CharRef.default` is included:

```
✨ Built in 1.53s
dist/index.html              196 B    210ms
dist/index.8474176c.js    70.68 KB    419ms
```

When it's replaced with `Dict.empty`:

```
✨ Built in 1.25s
dist/index.html             196 B    210ms
dist/index.8a124518.js    31.5 KB    341ms
```

It seems reasonable to make this configurable since you may not need to decode named char refs:

- You know that the html you're parsing doesn't have them.
- Or you don't care if they are parsed as undecoded text.

In such a case, you'd get to save 40KB of bundle size by turning decoding off.

